### PR TITLE
#57 Fix binary blob handling with MariaDB Connector/J 3.5.2+

### DIFF
--- a/dalesbred/src/main/java/org/dalesbred/Database.java
+++ b/dalesbred/src/main/java/org/dalesbred/Database.java
@@ -587,7 +587,7 @@ public final class Database {
      * Executes a query and creates a {@link ResultTable} from the results.
      */
     public @NotNull ResultTable findTable(@NotNull SqlQuery query) {
-        return executeQuery(new ResultTableResultSetProcessor(), query);
+        return executeQuery(new ResultTableResultSetProcessor(dialect), query);
     }
 
     /**

--- a/dalesbred/src/main/java/org/dalesbred/dialect/Dialect.java
+++ b/dalesbred/src/main/java/org/dalesbred/dialect/Dialect.java
@@ -112,7 +112,9 @@ public abstract class Dialect {
 
                 case "MariaDB":
                     log.debug("Automatically detected dialect MariaDB.");
-                    return new MariaDBDialect(connection.getMetaData().getDriverVersion());
+                    MariaDBDialect mariaDBDialect = new MariaDBDialect();
+                    mariaDBDialect.autodetectSettings(connection.getMetaData());
+                    return mariaDBDialect;
 
                 case "Oracle":
                     log.debug("Automatically detected dialect Oracle.");

--- a/dalesbred/src/main/java/org/dalesbred/dialect/Dialect.java
+++ b/dalesbred/src/main/java/org/dalesbred/dialect/Dialect.java
@@ -39,11 +39,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.sql.DataSource;
+import java.lang.reflect.Type;
 import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
 
 /**
@@ -54,8 +53,6 @@ public abstract class Dialect {
     private static final String SERIALIZATION_FAILURE = "40001";
 
     private static final Logger log = LoggerFactory.getLogger(Dialect.class);
-
-    protected final Map<String, Class<?>> resultSetMetaDataTypeOverrides = new ConcurrentHashMap<>();
 
     public @NotNull Object valueToDatabase(@NotNull Object value) {
         return value;
@@ -164,40 +161,7 @@ public abstract class Dialect {
         ArgumentBinder.bindArgument(ps, index, value);
     }
 
-    public Map<String, Class<?>> getResultSetMetaDataTypeOverrides() {
-        return resultSetMetaDataTypeOverrides;
-    }
-
-    // Some drivers (e.g. MySQL and H2) return version strings that do not look like typical SemVer strings and hence will not work with this
-    protected static class Version implements Comparable<Version> {
-
-        private final int[] numbers;
-
-        private Version(@NotNull String version) {
-            final String split[] = version.split("\\-")[0].split("\\.");
-            numbers = new int[split.length];
-            for (int i = 0; i < split.length; i++)
-                numbers[i] = Integer.parseInt(split[i]);
-        }
-
-        protected static Version withNumber(@NotNull String version) {
-            return new Version(version);
-        }
-
-        @Override
-        public int compareTo(@NotNull Version another) {
-            final int maxLength = Math.max(numbers.length, another.numbers.length);
-            for (int i = 0; i < maxLength; i++) {
-                final int left = i < numbers.length ? numbers[i] : 0;
-                final int right = i < another.numbers.length ? another.numbers[i] : 0;
-                if (left != right)
-                    return left < right ? -1 : 1;
-            }
-            return 0;
-        }
-
-        protected boolean isGreaterThanOrEqualTo(Version another) {
-            return this.compareTo(another) >= 0;
-        }
+    public @Nullable Type overrideResultSetMetaDataType(@NotNull String className) {
+        return null;
     }
 }

--- a/dalesbred/src/main/java/org/dalesbred/dialect/MariaDBDialect.java
+++ b/dalesbred/src/main/java/org/dalesbred/dialect/MariaDBDialect.java
@@ -22,20 +22,44 @@
 
 package org.dalesbred.dialect;
 
+import org.dalesbred.internal.utils.Version;
 import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.Type;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Support for MariaDB.
  */
 public class MariaDBDialect extends Dialect {
 
+    private static final Logger log = LoggerFactory.getLogger(MariaDBDialect.class);
+
+    private final @NotNull Map<String, Type> resultSetMetaDataTypeOverrides = new ConcurrentHashMap<>();
+
     public MariaDBDialect(@NotNull String driverVersion) {
+
+        // MariaDB Connector/J 3.x encodes byte array types in a way that is incompatible with Class.forName
+        resultSetMetaDataTypeOverrides.put("byte[]", byte[].class);
+
         // MariaDB Connector/J 3.5.2+ reports java.sql.Blob as the class name for binary blobs but returns them directly as byte arrays when fetched,
         // which fools the type conversion system and then causes issues in instantiator lookup.
         // https://jira.mariadb.org/browse/CONJ-1228
         // https://github.com/mariadb-corporation/mariadb-connector-j/commit/39ee017e2cdf37f4a54112cc7765e575d36c6fe6
-        if (Version.withNumber(driverVersion).isGreaterThanOrEqualTo(Version.withNumber("3.5.2")))
-            resultSetMetaDataTypeOverrides.put("java.sql.Blob", byte[].class);
+        try {
+            if (Version.parse(driverVersion).compareTo(Version.parse("3.5.2")) >= 0)
+                resultSetMetaDataTypeOverrides.put("java.sql.Blob", byte[].class);
+        } catch (IllegalArgumentException e) {
+            log.error("Could not parse driver version: {}", driverVersion, e);
+        }
     }
 
+    @Override
+    public @Nullable Type overrideResultSetMetaDataType(@NotNull String className) {
+        return resultSetMetaDataTypeOverrides.get(className);
+    }
 }

--- a/dalesbred/src/main/java/org/dalesbred/dialect/MariaDBDialect.java
+++ b/dalesbred/src/main/java/org/dalesbred/dialect/MariaDBDialect.java
@@ -22,8 +22,20 @@
 
 package org.dalesbred.dialect;
 
+import org.jetbrains.annotations.NotNull;
+
 /**
  * Support for MariaDB.
  */
 public class MariaDBDialect extends Dialect {
+
+    public MariaDBDialect(@NotNull String driverVersion) {
+        // MariaDB Connector/J 3.5.2+ reports java.sql.Blob as the class name for binary blobs but returns them directly as byte arrays when fetched,
+        // which fools the type conversion system and then causes issues in instantiator lookup.
+        // https://jira.mariadb.org/browse/CONJ-1228
+        // https://github.com/mariadb-corporation/mariadb-connector-j/commit/39ee017e2cdf37f4a54112cc7765e575d36c6fe6
+        if (Version.withNumber(driverVersion).isGreaterThanOrEqualTo(Version.withNumber("3.5.2")))
+            resultSetMetaDataTypeOverrides.put("java.sql.Blob", byte[].class);
+    }
+
 }

--- a/dalesbred/src/main/java/org/dalesbred/internal/instantiation/InstantiatorProvider.java
+++ b/dalesbred/src/main/java/org/dalesbred/internal/instantiation/InstantiatorProvider.java
@@ -354,4 +354,8 @@ public final class InstantiatorProvider {
     public @NotNull TypeConversionRegistry getTypeConversionRegistry() {
         return typeConversionRegistry;
     }
+
+    public @NotNull Dialect getDialect() {
+        return dialect;
+    }
 }

--- a/dalesbred/src/main/java/org/dalesbred/internal/instantiation/SqlArrayConversion.java
+++ b/dalesbred/src/main/java/org/dalesbred/internal/instantiation/SqlArrayConversion.java
@@ -37,8 +37,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
-import static java.util.Objects.requireNonNull;
-
 final class SqlArrayConversion {
 
     private final @NotNull Type elementType;
@@ -47,7 +45,7 @@ final class SqlArrayConversion {
 
     private SqlArrayConversion(@NotNull Type elementType, @NotNull InstantiatorProvider instantiatorRegistry) {
         this.elementType = elementType;
-        this.instantiatorRegistry = requireNonNull(instantiatorRegistry);
+        this.instantiatorRegistry = instantiatorRegistry;
     }
 
     public static @NotNull TypeConversion sqlArray(@NotNull Type elementType, @NotNull InstantiatorProvider instantiatorProvider,

--- a/dalesbred/src/main/java/org/dalesbred/internal/instantiation/SqlArrayConversion.java
+++ b/dalesbred/src/main/java/org/dalesbred/internal/instantiation/SqlArrayConversion.java
@@ -37,17 +37,17 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.function.Function;
 
+import static java.util.Objects.requireNonNull;
+
 final class SqlArrayConversion {
 
     private final @NotNull Type elementType;
 
     private final @NotNull InstantiatorProvider instantiatorRegistry;
 
-    private SqlArrayConversion(@NotNull Type elementType,
-                               @NotNull InstantiatorProvider instantiatorRegistry) {
-
+    private SqlArrayConversion(@NotNull Type elementType, @NotNull InstantiatorProvider instantiatorRegistry) {
         this.elementType = elementType;
-        this.instantiatorRegistry = instantiatorRegistry;
+        this.instantiatorRegistry = requireNonNull(instantiatorRegistry);
     }
 
     public static @NotNull TypeConversion sqlArray(@NotNull Type elementType, @NotNull InstantiatorProvider instantiatorProvider,
@@ -62,7 +62,9 @@ final class SqlArrayConversion {
             boolean allowNulls = !TypeUtils.isPrimitive(elementType);
             ResultSet resultSet = array.getResultSet();
             try {
-                NamedTypeList types = NamedTypeList.builder(1).add("value", ResultSetUtils.getColumnType(resultSet.getMetaData(), 2)).build();
+                NamedTypeList types = NamedTypeList.builder(1).add(
+                    "value", ResultSetUtils.getColumnType(resultSet.getMetaData(), instantiatorRegistry.getDialect(), 2)
+                ).build();
                 Instantiator<?> ctor = instantiatorRegistry.findInstantiator(elementType, types);
                 ArrayList<Object> result = new ArrayList<>();
 

--- a/dalesbred/src/main/java/org/dalesbred/internal/jdbc/ResultSetUtils.java
+++ b/dalesbred/src/main/java/org/dalesbred/internal/jdbc/ResultSetUtils.java
@@ -52,12 +52,9 @@ public final class ResultSetUtils {
     public static @NotNull Type getColumnType(@NotNull ResultSetMetaData metaData, @NotNull Dialect dialect, int column) throws SQLException {
         String className = metaData.getColumnClassName(column);
 
-        if (dialect.getResultSetMetaDataTypeOverrides().containsKey(className))
-            return dialect.getResultSetMetaDataTypeOverrides().get(className);
-
-        // MariaDB Connector/J 3.x encodes byte array types in a way that is incompatible with Class.forName
-        if (className.equals("byte[]"))
-            return byte[].class;
+        Type overrideType = dialect.overrideResultSetMetaDataType(className);
+        if (overrideType != null)
+            return overrideType;
 
         try {
             return Class.forName(className);

--- a/dalesbred/src/main/java/org/dalesbred/internal/result/InstantiatorRowMapper.java
+++ b/dalesbred/src/main/java/org/dalesbred/internal/result/InstantiatorRowMapper.java
@@ -61,7 +61,7 @@ public final class InstantiatorRowMapper<T> implements RowMapper<T> {
     @Override
     public T mapRow(@NotNull ResultSet resultSet) throws SQLException {
         if (types == null) {
-            types = ResultSetUtils.getTypes(resultSet.getMetaData());
+            types = ResultSetUtils.getTypes(resultSet.getMetaData(), instantiatorProvider.getDialect());
             ctor = instantiatorProvider.findInstantiator(cl, types);
             arguments = new Object[types.size()];
             instantiatorArguments = new InstantiatorArguments(types, arguments);

--- a/dalesbred/src/main/java/org/dalesbred/internal/result/MapResultSetProcessor.java
+++ b/dalesbred/src/main/java/org/dalesbred/internal/result/MapResultSetProcessor.java
@@ -61,7 +61,7 @@ public final class MapResultSetProcessor<K,V> implements ResultSetProcessor<Map<
     @Override
     public @NotNull Map<K, V> process(@NotNull ResultSet resultSet) throws SQLException {
 
-        NamedTypeList types = ResultSetUtils.getTypes(resultSet.getMetaData());
+        NamedTypeList types = ResultSetUtils.getTypes(resultSet.getMetaData(), instantiatorRegistry.getDialect());
         if (types.size() < 2)
             throw new UnexpectedResultException("Expected ResultSet with at least 2 columns, but got " + types.size() + " columns.");
 

--- a/dalesbred/src/main/java/org/dalesbred/internal/utils/Version.java
+++ b/dalesbred/src/main/java/org/dalesbred/internal/utils/Version.java
@@ -9,15 +9,19 @@ public final class Version implements Comparable<Version> {
     private final int[] numbers;
 
     // Some drivers (e.g. MySQL and H2) return version strings that do not look like typical SemVer strings and hence will not work with this
-    private Version(@NotNull String version) throws IllegalArgumentException {
+    private Version(@NotNull String version) {
         String[] split = version.split("\\-")[0].split("\\.");
         numbers = new int[split.length];
         for (int i = 0; i < split.length; i++)
             numbers[i] = Integer.parseInt(split[i]);
     }
 
-    public static Version parse(@NotNull String version) {
-        return new Version(version);
+    public static Version parse(@NotNull String version) throws InstantiationException {
+        try {
+            return new Version(version);
+        } catch (IllegalArgumentException e) {
+            throw new InstantiationException(e.getMessage());
+        }
     }
 
     @Override

--- a/dalesbred/src/main/java/org/dalesbred/internal/utils/Version.java
+++ b/dalesbred/src/main/java/org/dalesbred/internal/utils/Version.java
@@ -1,0 +1,33 @@
+package org.dalesbred.internal.utils;
+
+import org.jetbrains.annotations.NotNull;
+
+import static java.lang.Math.min;
+
+public final class Version implements Comparable<Version> {
+
+    private final int[] numbers;
+
+    // Some drivers (e.g. MySQL and H2) return version strings that do not look like typical SemVer strings and hence will not work with this
+    private Version(@NotNull String version) throws IllegalArgumentException {
+        String[] split = version.split("\\-")[0].split("\\.");
+        numbers = new int[split.length];
+        for (int i = 0; i < split.length; i++)
+            numbers[i] = Integer.parseInt(split[i]);
+    }
+
+    public static Version parse(@NotNull String version) {
+        return new Version(version);
+    }
+
+    @Override
+    public int compareTo(@NotNull Version another) {
+        for (int i = 0; i < min(numbers.length, another.numbers.length); i++) {
+            int result = Integer.compare(numbers[i], another.numbers[i]);
+            if (result != 0)
+                return result;
+        }
+        return Integer.compare(numbers.length, another.numbers.length);
+    }
+
+}

--- a/dalesbred/src/test/kotlin/org/dalesbred/dialect/MariaDBDialectTest.kt
+++ b/dalesbred/src/test/kotlin/org/dalesbred/dialect/MariaDBDialectTest.kt
@@ -25,6 +25,7 @@ package org.dalesbred.dialect
 import org.dalesbred.TestDatabaseProvider
 import org.junit.Test
 import kotlin.test.assertEquals
+import kotlin.test.assertNull
 import kotlin.test.assertTrue
 
 class MariaDBDialectTest {
@@ -38,15 +39,13 @@ class MariaDBDialectTest {
     @Test
     fun `ResultSetMetaDataTypeOverrides should be empty for MariaDB ConnectorJ 3_5_1 or earlier`() {
         val dialect = MariaDBDialect("3.5.1")
-        assertTrue { dialect.resultSetMetaDataTypeOverrides.isEmpty() }
+        assertNull(dialect.overrideResultSetMetaDataType("java.sql.Blob"))
     }
 
     @Test
     fun `ResultSetMetaDataTypeOverrides should not be empty for MariaDB ConnectorJ 3_5_2 or later`() {
         val dialect = MariaDBDialect("3.5.2")
-        assertTrue { dialect.resultSetMetaDataTypeOverrides.isNotEmpty() }
-        assertTrue { dialect.resultSetMetaDataTypeOverrides.containsKey("java.sql.Blob") }
-        assertEquals(ByteArray::class.java, dialect.resultSetMetaDataTypeOverrides["java.sql.Blob"])
+        assertEquals(ByteArray::class.java, dialect.overrideResultSetMetaDataType("java.sql.Blob"))
     }
 
 }

--- a/dalesbred/src/test/kotlin/org/dalesbred/dialect/MariaDBDialectTest.kt
+++ b/dalesbred/src/test/kotlin/org/dalesbred/dialect/MariaDBDialectTest.kt
@@ -24,6 +24,7 @@ package org.dalesbred.dialect
 
 import org.dalesbred.TestDatabaseProvider
 import org.junit.Test
+import kotlin.test.assertEquals
 import kotlin.test.assertTrue
 
 class MariaDBDialectTest {
@@ -33,4 +34,19 @@ class MariaDBDialectTest {
         val dialect = Dialect.detect(TestDatabaseProvider.createMariaDBConnectionProvider())
         assertTrue { dialect is MariaDBDialect }
     }
+
+    @Test
+    fun `ResultSetMetaDataTypeOverrides should be empty for MariaDB ConnectorJ 3_5_1 or earlier`() {
+        val dialect = MariaDBDialect("3.5.1")
+        assertTrue { dialect.resultSetMetaDataTypeOverrides.isEmpty() }
+    }
+
+    @Test
+    fun `ResultSetMetaDataTypeOverrides should not be empty for MariaDB ConnectorJ 3_5_2 or later`() {
+        val dialect = MariaDBDialect("3.5.2")
+        assertTrue { dialect.resultSetMetaDataTypeOverrides.isNotEmpty() }
+        assertTrue { dialect.resultSetMetaDataTypeOverrides.containsKey("java.sql.Blob") }
+        assertEquals(ByteArray::class.java, dialect.resultSetMetaDataTypeOverrides["java.sql.Blob"])
+    }
+
 }

--- a/dalesbred/src/test/kotlin/org/dalesbred/dialect/MariaDBDialectTest.kt
+++ b/dalesbred/src/test/kotlin/org/dalesbred/dialect/MariaDBDialectTest.kt
@@ -38,13 +38,13 @@ class MariaDBDialectTest {
 
     @Test
     fun `ResultSetMetaDataTypeOverrides should be empty for MariaDB ConnectorJ 3_5_1 or earlier`() {
-        val dialect = MariaDBDialect("3.5.1")
+        val dialect = MariaDBDialect().apply { setBlobsAsByteArrays(false) }
         assertNull(dialect.overrideResultSetMetaDataType("java.sql.Blob"))
     }
 
     @Test
     fun `ResultSetMetaDataTypeOverrides should not be empty for MariaDB ConnectorJ 3_5_2 or later`() {
-        val dialect = MariaDBDialect("3.5.2")
+        val dialect = MariaDBDialect().apply { setBlobsAsByteArrays(true) }
         assertEquals(ByteArray::class.java, dialect.overrideResultSetMetaDataType("java.sql.Blob"))
     }
 

--- a/dalesbred/src/test/kotlin/org/dalesbred/internal/jdbc/ResultSetUtilsTest.kt
+++ b/dalesbred/src/test/kotlin/org/dalesbred/internal/jdbc/ResultSetUtilsTest.kt
@@ -1,26 +1,48 @@
 package org.dalesbred.internal.jdbc
 
+import org.dalesbred.dialect.DefaultDialect
+import org.dalesbred.dialect.MariaDBDialect
 import org.dalesbred.testutils.unimplemented
 import org.junit.Test
+import java.sql.Blob
 import java.sql.ResultSetMetaData
 import kotlin.test.assertEquals
 
 class ResultSetUtilsTest {
+
+    companion object {
+        private val DEFAULT_DIALECT = DefaultDialect()
+        private val MARIADB_DIALECT_OLD = MariaDBDialect("3.5.1")
+        private val MARIADB_DIALECT_CURRENT = MariaDBDialect("3.5.2")
+    }
 
     @Test
     fun `column type resolution`() {
         val metadata = MockResultSetMetaData(
             classNames = listOf("java.lang.String", "[Ljava.lang.String;", "[B")
         )
-        assertEquals(String::class.java, ResultSetUtils.getColumnType(metadata, 1))
-        assertEquals(Array<String>::class.java, ResultSetUtils.getColumnType(metadata, 2))
-        assertEquals(ByteArray::class.java, ResultSetUtils.getColumnType(metadata, 3))
+        assertEquals(String::class.java, ResultSetUtils.getColumnType(metadata, DEFAULT_DIALECT, 1))
+        assertEquals(Array<String>::class.java, ResultSetUtils.getColumnType(metadata, DEFAULT_DIALECT, 2))
+        assertEquals(ByteArray::class.java, ResultSetUtils.getColumnType(metadata, DEFAULT_DIALECT, 3))
     }
 
     @Test
     fun `resolving byte array types for MariaDB`() {
         val metadata = MockResultSetMetaData(classNames = listOf("byte[]"))
-        assertEquals(ByteArray::class.java, ResultSetUtils.getColumnType(metadata, 1))
+        assertEquals(ByteArray::class.java, ResultSetUtils.getColumnType(metadata, MARIADB_DIALECT_OLD, 1))
+        assertEquals(ByteArray::class.java, ResultSetUtils.getColumnType(metadata, MARIADB_DIALECT_CURRENT, 1))
+    }
+
+    @Test
+    fun `resolving binary blob types for MariaDB ConnectorJ 3_5_1 or earlier`() {
+        val metadata = MockResultSetMetaData(classNames = listOf("java.sql.Blob"))
+        assertEquals(Blob::class.java, ResultSetUtils.getColumnType(metadata, MARIADB_DIALECT_OLD, 1))
+    }
+
+    @Test
+    fun `resolving binary blob types for MariaDB ConnectorJ 3_5_2 or later`() {
+        val metadata = MockResultSetMetaData(classNames = listOf("java.sql.Blob"))
+        assertEquals(ByteArray::class.java, ResultSetUtils.getColumnType(metadata, MARIADB_DIALECT_CURRENT, 1))
     }
 
     class MockResultSetMetaData(val classNames: List<String>) : ResultSetMetaData by unimplemented() {

--- a/dalesbred/src/test/kotlin/org/dalesbred/internal/jdbc/ResultSetUtilsTest.kt
+++ b/dalesbred/src/test/kotlin/org/dalesbred/internal/jdbc/ResultSetUtilsTest.kt
@@ -12,8 +12,8 @@ class ResultSetUtilsTest {
 
     companion object {
         private val DEFAULT_DIALECT = DefaultDialect()
-        private val MARIADB_DIALECT_OLD = MariaDBDialect("3.5.1")
-        private val MARIADB_DIALECT_CURRENT = MariaDBDialect("3.5.2")
+        private val MARIADB_DIALECT_OLD = MariaDBDialect().apply { setBlobsAsByteArrays(false) }
+        private val MARIADB_DIALECT_CURRENT = MariaDBDialect().apply { setBlobsAsByteArrays(true) }
     }
 
     @Test


### PR DESCRIPTION
Pull request for #57 as requested (pun intended).

After some initial misadventures with different exploratory approaches it turned out that the suggested solution of passing down the dialect to `ResultSetUtils` and just overriding whatever types `ResultSetMetaData` returns didn't require that extensive changes after all.

There are obviously multiple ways how to handle the driver version specific stuff and I opted to use this rudimentary version parser found from some gist that doesn't understand more exotic version strings but anything more sophisticated stuff seemed like overkill for this case, and I didn't want to introduce another runtime dependency with some SemVer parser library.

The changes were tested with MariaDB Connector/J versions 2.7.12, 3.5.1 and 3.5.3 with both basic containerized tests and our actual application tests; no issues were encountered.